### PR TITLE
Update portal front page links

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,9 @@
         These resources may be other github orgs, repos, or gists; links to documentation; or simply answers to
         questions.
       </p>
-      <p class="mt-5"><a href="https://github.com/uillinois-community/uillinois-community.github.io/issues"
-          class="btn btn-info">Ask a question &rarr;</a>
+      <p class="mt-5">
+        <a href="https://github.com/uillinois-community/uillinois-community.github.io/discussions"
+          class="btn btn-info mx-3">Ask a question &rarr;</a>
       </p>
     </div>
     <div>
@@ -41,7 +42,7 @@
       <ul>
         <li><a href="github-actions/">GitHub Actions</a></li>
       </ul>
-    </div>  
+    </div>
   </main>
   <footer class="border-top my-3 pt-3">
     <div class="container">

--- a/index.html
+++ b/index.html
@@ -32,9 +32,12 @@
         These resources may be other github orgs, repos, or gists; links to documentation; or simply answers to
         questions.
       </p>
-      <p class="mt-5">
+      <p class="mt-5 d-flex flex-row">
         <a href="https://github.com/uillinois-community/uillinois-community.github.io/discussions"
           class="btn btn-info mx-3">Ask a question &rarr;</a>
+
+        <a href="https://github.com/uillinois-community/uillinois-community.github.io/issues"
+          class="btn btn-secondary mx-3">Update this page &rarr;</a>
       </p>
     </div>
     <div>


### PR DESCRIPTION
## Summary

* Directs questions to repo discussion board (closes #22).
* Adds button directing portal page updates to issue queue.

## Discussion

I would like to give people a way to request updates to the portal page, and it seems appropriate to direct them to the issue queue. Should that button/link be given equal weight to the discussion button? Does the link text correctly limit scope to the community portal page?