### PR TITLE
update code of conduct contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -77,11 +77,11 @@ This code of conduct and its related procedures also applies to unacceptable beh
 
 ## 10. Contact info
 
-githubsupport@uillinois.edu
+github-community@uillinois.edu
 
 ## 11. License and attribution
 
-The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+The Citizen Code of Conduct is distributed by [Stumptown Syndicate](http://stumptownsyndicate.org) under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
 
 Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
 


### PR DESCRIPTION
Changes [code of conduct contact](https://github.com/uillinois-community/uillinois-community.github.io/blob/contact-email/CODE_OF_CONDUCT.md#10-contact-info) to github-community@uillinois.edu (per Robyn). Closes #38.