### PR TITLE
Add check that site is serving via GitHub pages

### DIFF
--- a/.github/workflows/live_site_check.yml
+++ b/.github/workflows/live_site_check.yml
@@ -1,0 +1,22 @@
+
+name: Test site is live
+
+on: 
+  push:
+    branches:
+      - main
+      
+jobs:
+  robot_test:
+    runs-on: ubuntu-latest
+    name: Run Robot Framework Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Robot Framework
+        uses: joonvena/robotframework-docker-action@v1.0
+        with:
+          browser: 'chrome'
+          robot_tests_dir: tests/robot
+          robot_reports_dir: tests/robot/reports
+          robot_runner_image: ppodgorsek/robot-framework@5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site
 gh-pages
 gh-pages.pub
 node_modules
+# Ignore RobotFramework test run output
+tests/robot/reports     

--- a/tests/robot/CONTRIBUTING.md
+++ b/tests/robot/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+
+
+To run the robot tests in `Docker`:
+
+```sh
+
+git clone git@github.com:uillinois-community/uillinois-community.github.io.git
+cd uillinois-community.github.io/tests
+docker run -v ${PWD}/tests/reports:/opt/robotframework/reports:Z -v ${PWD}/tests:/opt/robotframework/tests:Z ppodgorsek/robot-framework:latest
+```

--- a/tests/robot/CONTRIBUTING.md
+++ b/tests/robot/CONTRIBUTING.md
@@ -6,5 +6,5 @@ To run the robot tests in `Docker`:
 
 git clone git@github.com:uillinois-community/uillinois-community.github.io.git
 cd uillinois-community.github.io/tests
-docker run -v ${PWD}/tests/reports:/opt/robotframework/reports:Z -v ${PWD}/tests:/opt/robotframework/tests:Z ppodgorsek/robot-framework:latest
+docker run -v ${PWD}/tests/robot/reports:/opt/robotframework/reports:Z -v ${PWD}/tests/robot:/opt/robotframework/tests:Z ppodgorsek/robot-framework:latest
 ```

--- a/tests/robot/CONTRIBUTING.md
+++ b/tests/robot/CONTRIBUTING.md
@@ -5,6 +5,6 @@ To run the robot tests in `Docker`:
 ```sh
 
 git clone git@github.com:uillinois-community/uillinois-community.github.io.git
-cd uillinois-community.github.io/tests
+cd uillinois-community.github.io
 docker run -v ${PWD}/tests/robot/reports:/opt/robotframework/reports:Z -v ${PWD}/tests/robot:/opt/robotframework/tests:Z ppodgorsek/robot-framework:latest
 ```

--- a/tests/robot/gh-pages.robot
+++ b/tests/robot/gh-pages.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+
+Documentation    Verifies that our GitHub Pages hosted site is live.
+
+Library   SeleniumLibrary     # https://robotframework.org/SeleniumLibrary/SeleniumLibrary.html
+
+
+*** Variables ***
+
+${SITEURL}        https://uillinois-community.github.io/
+
+
+*** Test Cases ***
+
+GitHub Pages site is being served as expected
+
+  Open Browser                ${SITEURL}
+  Page should contain         University of Illinois      
+  Page should contain         GitHub Service Community Portal
+  Page should contain         Ask a question
+  Page should contain         Explore community resources
+  Page should contain         Update this page


### PR DESCRIPTION
## Context

We have some old `Dependabot` updates that should probably just get merged, but are waiting on a manual check that the site is still live. This update will at least check that the site is still live periodically after each change to the main branch.

Since this is a live check against GitHub the served GitHub pages, there's some chance of timing issues. Work-around, if that happens, is to click 're-run' on the action in the GitHub interface. If that does happen, I suspect we can tweak the GitHub workflows to avoid the issue, but we won't really know if that is needed until we're running the tests.

## Changes

- Add a RobotFramework test that verifies that the site is being serving from `https://uillinois-community.github.io/` with key bits of the front page intact.
- Add the `.robot` test to our CI/CD automation
- Add instructions for running the robot files locally in a Docker container to aid in updating the tests when needed.
